### PR TITLE
Add touch_interaction to wand

### DIFF
--- a/mods/regulus_tools/init.lua
+++ b/mods/regulus_tools/init.lua
@@ -13,5 +13,6 @@ minetest.register_tool("regulus_tools:test",{
             --minetest.chat_send_all("You used it"..tostring(itemstack:get_wear()))
             --return itemstack
         --end
-    end
+    end,
+    touch_interaction = "short_dig_long_place",
 })


### PR DESCRIPTION
This PR makes the wand usable with short tap instead of long tap on mobile. This allows for much more precise timing.